### PR TITLE
Handle WP/IF in such a way to allow nested calls.

### DIFF
--- a/x86.h
+++ b/x86.h
@@ -11,6 +11,8 @@
 #ifndef X86_H
 #define X86_H
 
+#define	FLAGS_IF (1 << 9)
+
 #define CR0_WP (1 << 16)
 #define CR0_NW (1 << 29)
 #define CR0_CD (1 << 30)
@@ -38,6 +40,19 @@ static inline void cr0_write(u64 val)
     asm volatile("mov cr0, %0;" :: "r" (val));
 }
 
+static inline u64 write_protect_disable()
+{
+    u64 cr0 = cr0_read();
+    cr0_write(cr0 & ~CR0_WP);
+    return cr0;
+}
+
+static inline void write_protect_restore(u64 cr0)
+{
+    // Use only WP bit of input
+    cr0_write(cr0_read() | (cr0 & CR0_WP));
+}
+
 static inline u64 cr3_read(void)
 {
     u64 reg;
@@ -63,7 +78,7 @@ static inline void cr4_pge_disable(void)
 
 static inline void wbinvd(void)
 {
-    asm volatile("wbinvd;");
+    asm volatile("wbinvd");
 }
 
 static inline void cpu_stop(void)
@@ -74,14 +89,16 @@ static inline void cpu_stop(void)
 
 static inline void outl(int port, unsigned int data)
 {
-    asm volatile("out %w1,%0" : : "a" (data), "d" (port));
+    asm volatile("out %w1, %0" : : "a" (data), "d" (port));
 }
 
 static inline void wrmsr(u32 msr_id, u64 msr_value)
 {
-    asm volatile (
+    asm volatile(
         "wrmsr"
-        : :"c" (msr_id), "a" (msr_value&0xffffffff), "d" (msr_value>>32) );
+        :
+        : "c" (msr_id), "a" (msr_value & 0xffffffff), "d" (msr_value >> 32)
+        );
 }
 
 static inline void disable_interrupts(void)
@@ -92,6 +109,26 @@ static inline void disable_interrupts(void)
 static inline void enable_interrupts(void)
 {
     asm volatile("sti");
+}
+
+static inline u64 read_flags(void)
+{
+    u64 flags;
+    asm volatile("pushf; pop %0;" : "=r" (flags));
+    return flags;
+}
+
+static inline u64 intr_disable(void)
+{
+    u64 flags = read_flags();
+    disable_interrupts();
+    return flags;
+}
+
+static inline void intr_restore(u64 flags)
+{
+    // TODO should only IF be or'd in?
+    asm volatile("push %0; popf;" : : "rm" (flags) : "memory");
 }
 
 #endif


### PR DESCRIPTION
If caller of kexec_init() has WP=0, keep an extra sched_pin() refcount.
